### PR TITLE
meteor command line change

### DIFF
--- a/bin/mcli
+++ b/bin/mcli
@@ -35,4 +35,4 @@ fi
 
 export METEOR_NO_WEBAPP=1
 
-meteor --once --settings /tmp/settings.json
+meteor --once --raw-logs --settings /tmp/settings.json


### PR DESCRIPTION
Looks like recent meteor command line must add --raw-logs in order for the console output to work correctly.
